### PR TITLE
Add llama-cpp-python metal GPU support

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ necessary.
 
 #### 2. Build and install LLaMA C++ 
 
-After creating the Conda environment you can build and install LLaMA C++ with BLAS acceleratin by running the following shell 
+After creating the Conda environment you can build and install LLaMA C++ with BLAS acceleration by running the following shell 
 script.
 
 ```bash
@@ -70,26 +70,51 @@ This script does the following.
 5. Removes the `./src/llama-cpp` as it is no longer needed.
 6. Deactivates the Conda environment.
 
-### Installing LLaMA C++ (Mac OS)
+### LLaMA C++ with Metal GPU acceleration (Mac OS)
 
-After creating and activating the Conda environment you can install LLaMA C++ for Mac OS by running the following shell 
-script.
+TLDR: run the following command.
 
 ```bash
-./bin/install-llama-cpp-macos.sh
+./bin/create-conda-env.sh environment-metal-gpu.yml && ./bin/build-llama-cpp-metal-gpu.sh
 ```
 
-This script will install a *recent* build of LLaMA C++. If you wish to install a particular 
-[build number](https://github.com/ggerganov/llama.cpp/releases) for LLaMA C++ then you can pass the build number as a 
-command line argument when running the installation script.
+Details are covered below.
+
+#### 1. Create the Conda environment
+
+After adding any necessary dependencies that should be installed via `conda/mamba` to the `environment-metal-gpu.yml` file and any 
+dependencies that should be installed via `pip` to the `requirements-metal-gpu.txt` file you create the Conda environment in a 
+sub-directory `./env`of your project directory by running the following shell script.
 
 ```bash
-./bin/install-llama-cpp-macos.sh $BUILD
-``` 
+./bin/create-conda-env.sh environment-metal-gpu.yml
+```
 
-The script will download the archive of pre-compiled binaries for LLaMA C++ and extract them into the 
-`./bin/llama-cpp/$BUILD/` directory. The script then symlinks the binaries into the `bin/` directory of the Conda 
-environment so that they get properly added to the environment.
+Once the new environment has been created you can activate the environment with the following command.
 
+```bash
+conda activate ./env
+```
+
+Note that the `./env` directory is *not* under version control as it can always be re-created as 
+necessary.
+
+#### 2. Build and install LLaMA C++ 
+
+After creating the Conda environment you can build and install LLaMA C++ with Metal GPU acceleration by running the 
+following shell script.
+
+```bash
+./bin/build-llama-cpp-metal-gpu.sh
+```
+
+This script does the following.
+
+1. Clones [LLaMA C++](https://github.com/ggerganov/llama.cpp into `./src/llama-cpp`.
+2. Activates the Conda environment.
+3. Builds LLaMA C++ with support for Metal GPU acceleration in `./build/llama-cpp`.
+4. Installs the binaries into the `bin/` directory of the Conda environment.
+5. Removes the `./src/llama-cpp` as it is no longer needed.
+6. Deactivates the Conda environment.
 
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,14 @@ TLDR: run the following command.
 
 Details are covered below.
 
+#### 0. Install XCode and Command Line Tools
+
+Install [XCode](https://developer.apple.com/xcode/). Then run the following command to install XCode Command Line Tools.
+
+```bash
+xcode-select --install
+```
+
 #### 1. Create the Conda environment
 
 After adding any necessary dependencies that should be installed via `conda/mamba` to the `environment-metal-gpu.yml` file and any 

--- a/README.md
+++ b/README.md
@@ -23,10 +23,20 @@ script using the following command.
 ./bin/install-miniforge.sh
 ```
 
-### Creating the Conda environment
+### LLaMA C++ with BLAS acceleration (Mac OS, Linux, Windows)
 
-After adding any necessary dependencies that should be downloaded via `conda` to the `environment.yml` file and any 
-dependencies that should be downloaded via `pip` to the `requirements.txt` file you create the Conda environment in a 
+TLDR: run the following command.
+
+```bash
+./bin/create-conda-env.sh && ./bin/build-llama-cpp.sh
+```
+
+Details are covered below.
+
+#### 1. Create the Conda environment
+
+After adding any necessary dependencies that should be installed via `conda/mamba` to the `environment.yml` file and any 
+dependencies that should be installed via `pip` to the `requirements.txt` file you create the Conda environment in a 
 sub-directory `./env`of your project directory by running the following shell script.
 
 ```bash
@@ -41,6 +51,24 @@ conda activate ./env
 
 Note that the `./env` directory is *not* under version control as it can always be re-created as 
 necessary.
+
+#### 2. Build and install LLaMA C++ 
+
+After creating the Conda environment you can build and install LLaMA C++ with BLAS acceleratin by running the following shell 
+script.
+
+```bash
+./bin/build-llama-cpp.sh
+```
+
+This script does the following.
+
+1. Clones [LLaMA C++](https://github.com/ggerganov/llama.cpp into `./src/llama-cpp`.
+2. Activates the Conda environment.
+3. Builds LLaMA C++ with support for CPU acceleration using OpenBlas in `./build/llama-cpp`.
+4. Symlinks the binaries into the `bin/` directory of the Conda environment.
+5. Removes the `./src/llama-cpp` as it is no longer needed.
+6. Deactivates the Conda environment.
 
 ### Installing LLaMA C++ (Mac OS)
 

--- a/bin/build-llama-cpp-metal-gpu.sh
+++ b/bin/build-llama-cpp-metal-gpu.sh
@@ -15,13 +15,10 @@ conda activate "$ENV_PREFIX"
 # create the build configuration files
 BUILD_DIR="$PROJECT_DIR"/build/llama-cpp
 if [ -d "$BUILD_DIR" ]; then rm -rf "$BUILD_DIR"; fi
-
 cmake -S "$SRC_DIR" -B "$BUILD_DIR" \
     -DCMAKE_INSTALL_PREFIX="$ENV_PREFIX" `# install binaries into conda environment` \
-    -DGGML_METAL=OFF            `# disable support for metal on mac silicon` \
-    -DGGML_LLAMAFILE=OFF        `# support for Q4_0_4_4 quantization` \
-    -DGGML_BLAS=ON              `# support for CPU accleration using BLAS` \
-    -DGGML_BLAS_VENDOR=OpenBLAS
+    -DGGML_METAL=ON                      `# enable support for Metal GPU accleration` \
+    -DGGML_LLAMAFILE=OFF                 `# support for Q4_0_4_4 quantization`
 
 # build llama.cpp
 cmake --build "$BUILD_DIR" --config Release 

--- a/bin/build-llama-cpp.sh
+++ b/bin/build-llama-cpp.sh
@@ -1,0 +1,32 @@
+#!/bin/bash --login
+
+# entire script fails if a single command fails
+set -e
+
+# clone the llama.cpp repository
+PROJECT_DIR="$PWD"
+SRC_DIR="$PROJECT_DIR"/src/llama-cpp
+git clone git@github.com:ggerganov/llama.cpp.git "$SRC_DIR"
+
+# activate the conda environment
+ENV_PREFIX="$PROJECT_DIR"/env
+conda activate "$ENV_PREFIX"
+
+# compile using cmake with BLAS support
+BUILD_DIR="$PROJECT_DIR"/build/llama-cpp
+cmake -S "$SRC_DIR" -B "$BUILD_DIR" \
+    -DGGML_METAL=OFF            `# disable support for metal on mac silicon` \
+    -DGGML_LLAMAFILE=OFF        `# support for Q4_0_4_4 quantization` \
+    -DGGML_BLAS=ON              `# support for CPU accleration using BLAS` \
+    -DGGML_BLAS_VENDOR=OpenBLAS
+
+cmake --build "$BUILD_DIR" --config Release
+
+# symlink llama.cpp binaries into the Conda environment bin directory
+ln -sf "$BUILD_DIR"/bin/* "$ENV_PREFIX"/bin
+
+# remove the llama.cpp source code
+rm -rf "$SRC_DIR"
+
+# deactivate the conda environment
+conda deactivate

--- a/bin/create-conda-environment.sh
+++ b/bin/create-conda-environment.sh
@@ -3,6 +3,9 @@
 # entire script fails if a single command fails
 set -e
 
+# disable pip cache
+export PIP_NO_CACHE_DIR=true
+
 # create the conda environment
 PROJECT_DIR="$PWD"
 ENV_PREFIX="$PROJECT_DIR"/env

--- a/bin/create-conda-environment.sh
+++ b/bin/create-conda-environment.sh
@@ -6,4 +6,5 @@ set -e
 # create the conda environment
 PROJECT_DIR="$PWD"
 ENV_PREFIX="$PROJECT_DIR"/env
-mamba env create --prefix $ENV_PREFIX --file "$PROJECT_DIR"/environment.yml --yes
+ENV_FILE="${1-environment.yml}"
+mamba env create --prefix $ENV_PREFIX --file "$PROJECT_DIR"/"$ENV_FILE" --yes

--- a/environment-metal-gpu.yml
+++ b/environment-metal-gpu.yml
@@ -1,0 +1,19 @@
+name: null
+
+channels:
+  - conda-forge
+  - nodefaults
+
+dependencies:
+  - ccache
+  - cmake
+  - diskcache
+  - jupyterlab
+  - jupyterlab-lsp
+  - numpy
+  - pip
+  - pip:
+    - -r requirements-metal-gpu.txt
+  - python
+  - python-lsp-server
+  - tqdm

--- a/environment-metal-gpu.yml
+++ b/environment-metal-gpu.yml
@@ -14,6 +14,7 @@ dependencies:
   - pip
   - pip:
     - -r requirements-metal-gpu.txt
+  - pkg-config
   - python
   - python-lsp-server
   - tqdm

--- a/environment.yml
+++ b/environment.yml
@@ -5,13 +5,19 @@ channels:
   - nodefaults
 
 dependencies:
+  - ccache
+  - cmake
+  - cxx-compiler
   - diskcache
   - jupyterlab
   - jupyterlab-lsp
   - numpy
+  - openblas
+  - openblas-ilp64
   - pip
   - pip:
     - -r requirements.txt
+  - pkg-config
   - python
   - python-lsp-server
   - tqdm

--- a/requirements-metal-gpu.txt
+++ b/requirements-metal-gpu.txt
@@ -1,2 +1,2 @@
 gguf
-llama-cpp-python --config-settings cmake.args="-DGGML_METAL=ON"
+llama-cpp-python --config-settings cmake.args="-DGGML_METAL=ON;-DGGML_LLAMAFILE=OFF"

--- a/requirements-metal-gpu.txt
+++ b/requirements-metal-gpu.txt
@@ -1,0 +1,2 @@
+gguf
+llama-cpp-python --config-settings cmake.args="-DGGML_METAL=ON"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 gguf
-llama-cpp-python
+llama-cpp-python --config-settings cmake.args="-DGGML_BLAS=ON;-DGGML_BLAS_VENDOR=OpenBLAS"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 gguf
-llama-cpp-python --config-settings cmake.args="-DGGML_BLAS=ON;-DGGML_BLAS_VENDOR=OpenBLAS"
+llama-cpp-python --config-settings cmake.args="-DGGML_METAL=OFF;-DGGML_LLAMAFILE=OFF;-DGGML_BLAS=ON;-DGGML_BLAS_VENDOR=OpenBLAS"


### PR DESCRIPTION
This PR adds support for building llama-cpp-python and llama.cpp itself with support for Metal GPU. It also fixes up the generic CPU build scripts with lessons learned.