### PR TITLE
Need to invlude the CMAKE_INSTALL_RPATH.

### DIFF
--- a/bin/build-llama-cpp-metal-gpu.sh
+++ b/bin/build-llama-cpp-metal-gpu.sh
@@ -13,10 +13,11 @@ BUILD_DIR="$PROJECT_DIR"/build/llama-cpp
 if [ -d "$BUILD_DIR" ]; then rm -rf "$BUILD_DIR"; fi
 
 cmake -S "$SRC_DIR" -B "$BUILD_DIR" \
-    -DCMAKE_INSTALL_PREFIX="$PWD"/env `# install binaries into conda environment` \
-    -DGGML_ACCELERATE=ON              `# enable support for CPU acceleration` \
-    -DGGML_METAL=ON                   `# enable support for Metal GPU accleration` \
-    -DGGML_LLAMAFILE=OFF              `# support for Q4_0_4_4 quantization`
+    -DCMAKE_INSTALL_PREFIX="$PWD"/env    `# install binaries into conda environment` \
+    -DCMAKE_INSTALL_RPATH="$PWD"/env/lib `# insure that dyanmic libs can be found at runtime` \
+    -DGGML_ACCELERATE=ON                 `# enable support for CPU acceleration` \
+    -DGGML_METAL=ON                      `# enable support for Metal GPU accleration` \
+    -DGGML_LLAMAFILE=OFF                 `# support for Q4_0_4_4 quantization`
 
 # build llama.cpp
 cmake --build "$BUILD_DIR" --config Release 


### PR DESCRIPTION
This hotfix specifies the `CMAKE_INSTALL_RPATH` properly so that the dynamically loaded libraries are found at runtime.