### PR TITLE
Added example of using the LLAMA_CACHE variable.

### DIFF
--- a/notebooks/00-llama-cpp-basics.ipynb
+++ b/notebooks/00-llama-cpp-basics.ipynb
@@ -108,8 +108,20 @@
    "source": [
     "%%bash\n",
     "\n",
+    "export LLAMA_CACHE=\"../models\"\n",
+    "\n",
     "MODEL_URL=https://huggingface.co/ggml-org/gemma-1.1-7b-it-Q4_K_M-GGUF/resolve/main/gemma-1.1-7b-it.Q4_K_M.gguf\n",
     "llama-cli --model-url \"$MODEL_URL\" --prompt \"Once upon a time\"\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "35b5675a-5c20-44b2-a8a9-5af7ac00cc51",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "MODEL = \"../models/gemma-1.1-7b-it.Q4_K_M.gguf\""
    ]
   },
   {
@@ -129,9 +141,21 @@
    "source": [
     "%%bash\n",
     "\n",
+    "export LLAMA_CACHE=\"../models\"\n",
+    "\n",
     "HF_REPO=\"ggml-org/gemma-1.1-7b-it-Q4_K_M-GGUF\"\n",
     "HF_MODEL_FILE=\"gemma-1.1-7b-it.Q4_K_M.gguf\"\n",
     "llama-cli --hf-repo \"$HF_REPO\" --hf-file \"$HF_MODEL_FILE\" --prompt \"Once upon a time\"\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5dea2b37-82cb-4301-b8a1-543f506d26dd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "MODEL = \"../models/gemma-1.1-7b-it.Q4_K_M.gguf\""
    ]
   },
   {


### PR DESCRIPTION
This PR adds examples of how to use the `LLAMA_CACHE` variable to control where models downloaded from urls or HF get stored. Setting this variable helps avoid models getting installed outside of the environment in the users home directory.